### PR TITLE
Demo how to Al-Mg-Si results

### DIFF
--- a/kawin/run_simulation.py
+++ b/kawin/run_simulation.py
@@ -892,7 +892,7 @@ if __name__ == '__main__':
     os.makedirs(out_dir, exist_ok=True)
 
     T_C          = 175.0   # aging temperature (°C)
-    AGING_TIME_H = 100.0   # aging time (h)
+    AGING_TIME_H = 24.0   # aging time (h)
 
     # Compositions (mole fractions)
     # Al-0.3Mg-1Si:      Mg=0.3 wt.% → 0.003330, Si=1.0 wt.% → 0.009607
@@ -900,9 +900,9 @@ if __name__ == '__main__':
     # Al-4.5Cu-0.5Mg-1Si: Cu=4.5 wt.% → 0.01961,
     #                      Mg=0.5 wt.% → 0.005551, Si=1.0 wt.% → 0.009604
     examples = [
-        dict(label='Al-0.3Mg-1Si',       mg=0.003330, si=0.009607, cu=0.0),
-        dict(label='Al-4.5Cu',            mg=0.0,      si=0.0,      cu=0.01961),
-        dict(label='Al-4.5Cu-0.5Mg-1Si', mg=0.005551, si=0.009604, cu=0.01961),
+        dict(label='Al-0.21Mg-0.7Si',    mg=0.002327, si=0.006725, cu=0.0),
+        # dict(label='Al-4.5Cu',            mg=0.0,      si=0.0,      cu=0.01961),
+        # dict(label='Al-4.5Cu-0.5Mg-1Si', mg=0.005551, si=0.009604, cu=0.01961),
     ]
     colors = ['steelblue', 'tomato', 'seagreen']
 


### PR DESCRIPTION
1) Set up virtual environment: pip install kawin and source this environment. 
Reference https://github.com/materialsgenomefoundation/kawin

2) cd the the root folder, run: `python3 kawin/run_simulation.py`

3) the result should be plotted in _results/kawin_examples/alloy_examples_sigma_y.png_

4) read code diff. Note that I am using Al-0.21Mg-0.7Si.
 The nominal input composition is Al-0.3Mg-7Si, but after inputing this composition in the function `_get_composition_in_FCC`, the output should be Al-0.2Mg-0.7Si because:
 a) max si content is set as 1 
 b) the eff_factor = 0.7. 
So 0.3 Mg*0.7=0.21 Mg
    1 Si * 0.7 =0.7 Si